### PR TITLE
Update Kubernetes to v1.0.1 and etcd to v2.1.1

### DIFF
--- a/kubernetes/recipes/etcd.rb
+++ b/kubernetes/recipes/etcd.rb
@@ -2,7 +2,7 @@ bash 'install_etcd' do
   user 'root'
   cwd '/tmp'
   code <<-EOH
-  wget https://github.com/coreos/etcd/releases/download/v2.1.1/etcd-v2.1.1-linux-amd64.tar.gz
+  wget --max-redirect 255 https://github.com/coreos/etcd/releases/download/v2.1.1/etcd-v2.1.1-linux-amd64.tar.gz
   tar zxvf etcd-v2.1.0-rc.0-linux-amd64.tar.gz
   cd etcd-v2.1.0-rc.0-linux-amd64
   cp etcd etcdctl /usr/local/bin

--- a/kubernetes/recipes/etcd.rb
+++ b/kubernetes/recipes/etcd.rb
@@ -2,9 +2,9 @@ bash 'install_etcd' do
   user 'root'
   cwd '/tmp'
   code <<-EOH
-  wget --max-redirect 255 -O etcd.tar.gz https://github.com/coreos/etcd/releases/download/v2.1.1/etcd-v2.1.1-linux-amd64.tar.gz
-  tar zxvf etcd.tar.gz
-  cd etcd
+  wget --max-redirect 255 https://github.com/coreos/etcd/releases/download/v2.1.1/etcd-v2.1.1-linux-amd64.tar.gz
+  tar zxvf etcd-v2.1.1-linux-amd64.tar.gz
+  cd etcd-v2.1.1-linux-amd64
   cp etcd etcdctl /usr/local/bin
   EOH
 end

--- a/kubernetes/recipes/etcd.rb
+++ b/kubernetes/recipes/etcd.rb
@@ -2,9 +2,9 @@ bash 'install_etcd' do
   user 'root'
   cwd '/tmp'
   code <<-EOH
-  wget --max-redirect 255 https://github.com/coreos/etcd/releases/download/v2.1.1/etcd-v2.1.1-linux-amd64.tar.gz
-  tar zxvf etcd-v2.1.0-rc.0-linux-amd64.tar.gz
-  cd etcd-v2.1.0-rc.0-linux-amd64
+  wget --max-redirect 255 -O etcd.tar.gz https://github.com/coreos/etcd/releases/download/v2.1.1/etcd-v2.1.1-linux-amd64.tar.gz
+  tar zxvf etcd.tar.gz
+  cd etcd
   cp etcd etcdctl /usr/local/bin
   EOH
 end

--- a/kubernetes/recipes/etcd.rb
+++ b/kubernetes/recipes/etcd.rb
@@ -2,7 +2,7 @@ bash 'install_etcd' do
   user 'root'
   cwd '/tmp'
   code <<-EOH
-  wget https://github.com/coreos/etcd/releases/download/v2.1.0-rc.0/etcd-v2.1.0-rc.0-linux-amd64.tar.gz
+  wget https://github.com/coreos/etcd/releases/download/v2.1.1/etcd-v2.1.1-linux-amd64.tar.gz
   tar zxvf etcd-v2.1.0-rc.0-linux-amd64.tar.gz
   cd etcd-v2.1.0-rc.0-linux-amd64
   cp etcd etcdctl /usr/local/bin

--- a/kubernetes/recipes/kubernetes.rb
+++ b/kubernetes/recipes/kubernetes.rb
@@ -1,9 +1,8 @@
 bash 'install_kubernetes' do
   user 'root'
   cwd '/tmp'
-  #wget https://github.com/GoogleCloudPlatform/kubernetes/releases/download/v0.18.2/kubernetes.tar.gz
   code <<-EOH
-  wget https://github.com/GoogleCloudPlatform/kubernetes/releases/download/v0.20.2/kubernetes.tar.gz
+  wget https://github.com/GoogleCloudPlatform/kubernetes/releases/download/v1.0.1/kubernetes.tar.gz
   tar zxvf kubernetes.tar.gz
   cd kubernetes/server
   tar zxvf kubernetes-server-linux-amd64.tar.gz

--- a/kubernetes/recipes/kubernetes.rb
+++ b/kubernetes/recipes/kubernetes.rb
@@ -2,7 +2,7 @@ bash 'install_kubernetes' do
   user 'root'
   cwd '/tmp'
   code <<-EOH
-  wget --max-redirect 255 -O kubernetes.tar.gz https://github.com/GoogleCloudPlatform/kubernetes/releases/download/v1.0.1/kubernetes.tar.gz
+  wget --max-redirect 255 https://github.com/GoogleCloudPlatform/kubernetes/releases/download/v1.0.1/kubernetes.tar.gz
   tar zxvf kubernetes.tar.gz
   cd kubernetes/server
   tar zxvf kubernetes-server-linux-amd64.tar.gz

--- a/kubernetes/recipes/kubernetes.rb
+++ b/kubernetes/recipes/kubernetes.rb
@@ -2,7 +2,7 @@ bash 'install_kubernetes' do
   user 'root'
   cwd '/tmp'
   code <<-EOH
-  wget https://github.com/GoogleCloudPlatform/kubernetes/releases/download/v1.0.1/kubernetes.tar.gz
+  wget --max-redirect 255 https://github.com/GoogleCloudPlatform/kubernetes/releases/download/v1.0.1/kubernetes.tar.gz
   tar zxvf kubernetes.tar.gz
   cd kubernetes/server
   tar zxvf kubernetes-server-linux-amd64.tar.gz

--- a/kubernetes/recipes/kubernetes.rb
+++ b/kubernetes/recipes/kubernetes.rb
@@ -2,7 +2,7 @@ bash 'install_kubernetes' do
   user 'root'
   cwd '/tmp'
   code <<-EOH
-  wget --max-redirect 255 https://github.com/GoogleCloudPlatform/kubernetes/releases/download/v1.0.1/kubernetes.tar.gz
+  wget --max-redirect 255 -O kubernetes.tar.gz https://github.com/GoogleCloudPlatform/kubernetes/releases/download/v1.0.1/kubernetes.tar.gz
   tar zxvf kubernetes.tar.gz
   cd kubernetes/server
   tar zxvf kubernetes-server-linux-amd64.tar.gz


### PR DESCRIPTION
Hi @carol-hsu 

Here is a PR that update Kubernetes version to **1.0.1**. also etcd to **2.1.1**.

in addition, i've got an issue when downloading etcd due to many http redirection.
i've also increased --max-redirects from 10 to 255 as a workaround.

please review and merge.