### PR TITLE
downgrade etcd version to 2.0.12

### DIFF
--- a/kubernetes/recipes/docker.rb
+++ b/kubernetes/recipes/docker.rb
@@ -1,19 +1,6 @@
-package "docker-io" do
+package "docker" do
 	action :install
-	notifies :run, 'bash[update-docker]', :delayed
 end
-
-
-bash 'update-docker' do
-	user 'root'
-	cwd '/tmp'
-	code <<-EOH
-	wget https://get.docker.com/builds/Linux/x86_64/docker-1.6.2 -O /usr/bin/docker
-	EOH
-
-	action :nothing
-end
-
 
 service "docker" do
 	action :disable

--- a/kubernetes/recipes/etcd.rb
+++ b/kubernetes/recipes/etcd.rb
@@ -2,9 +2,9 @@ bash 'install_etcd' do
   user 'root'
   cwd '/tmp'
   code <<-EOH
-  wget --max-redirect 255 https://github.com/coreos/etcd/releases/download/v2.0.12/etcd-v2.0.12-linux-amd64.tar.gz
-  tar zxvf etcd-v2.0.12-linux-amd64.tar.gz
-  cd etcd-v2.0.12-linux-amd64
+  wget --max-redirect 255 https://github.com/coreos/etcd/releases/download/v2.1.1/etcd-v2.1.1-linux-amd64.tar.gz
+  tar zxvf etcd-v2.1.1-linux-amd64.tar.gz
+  cd etcd-v2.1.1-linux-amd64
   cp etcd etcdctl /usr/local/bin
   EOH
 end

--- a/kubernetes/recipes/etcd.rb
+++ b/kubernetes/recipes/etcd.rb
@@ -2,9 +2,9 @@ bash 'install_etcd' do
   user 'root'
   cwd '/tmp'
   code <<-EOH
-  wget --max-redirect 255 https://github.com/coreos/etcd/releases/download/v2.1.1/etcd-v2.1.1-linux-amd64.tar.gz
-  tar zxvf etcd-v2.1.1-linux-amd64.tar.gz
-  cd etcd-v2.1.1-linux-amd64
+  wget --max-redirect 255 https://github.com/coreos/etcd/releases/download/v2.0.12/etcd-v2.0.12-linux-amd64.tar.gz
+  tar zxvf etcd-v2.0.12-linux-amd64.tar.gz
+  cd etcd-v2.0.12-linux-amd64
   cp etcd etcdctl /usr/local/bin
   EOH
 end

--- a/kubernetes/recipes/flanneld.rb
+++ b/kubernetes/recipes/flanneld.rb
@@ -2,9 +2,9 @@ bash 'install_flannel' do
   user 'root'
   cwd '/tmp'
   code <<-EOH
-  wget --max-redirect 255 https://github.com/coreos/flannel/releases/download/v0.4.1/flannel-0.4.1-linux-amd64.tar.gz
-  tar zxvf flannel-0.4.1-linux-amd64.tar.gz
-  cd flannel-0.4.1
+  wget --max-redirect 255 https://github.com/coreos/flannel/releases/download/v0.5.2/flannel-0.5.2-linux-amd64.tar.gz
+  tar zxvf flannel-0.5.2-linux-amd64.tar.gz
+  cd flannel-0.5.2
   cp flanneld /usr/local/bin
   EOH
 end

--- a/kubernetes/recipes/flanneld.rb
+++ b/kubernetes/recipes/flanneld.rb
@@ -2,7 +2,7 @@ bash 'install_flannel' do
   user 'root'
   cwd '/tmp'
   code <<-EOH
-  wget https://github.com/coreos/flannel/releases/download/v0.4.1/flannel-0.4.1-linux-amd64.tar.gz
+  wget --max-redirect 255 https://github.com/coreos/flannel/releases/download/v0.4.1/flannel-0.4.1-linux-amd64.tar.gz
   tar zxvf flannel-0.4.1-linux-amd64.tar.gz
   cd flannel-0.4.1
   cp flanneld /usr/local/bin


### PR DESCRIPTION
Hi @carol-hsu 

this PR includes below changes

- etcd version downgrade from 2.1.1 to 2.0.12 (https://github.com/TrendMicroDCS/opsworks-recipes/pull/10#discussion_r35849248 )
- increase max-redirects when download flanneld 