### PR TITLE
enable IP Masq that allow to send a packet to outside world

### DIFF
--- a/kubernetes/recipes/docker.rb
+++ b/kubernetes/recipes/docker.rb
@@ -2,10 +2,14 @@ package "docker" do
 	action :install
 end
 
+package "bridge-utils" do
+  action :install
+end
+
+
 service "docker" do
 	action :disable
 end
-
 
 template "/etc/sysconfig/docker" do
     mode "0644"

--- a/kubernetes/templates/default/flanneld.erb
+++ b/kubernetes/templates/default/flanneld.erb
@@ -29,6 +29,7 @@ start() {
 	echo -n $"Starting $prog: "
 	daemon $prog \
 		--etcd-endpoints=http://root:<%= @etcd_password %>@<%= @elb_url %> \
+		-ip-masq=true \
 		> /var/log/flanneld.log 2>&1 &
 	RETVAL=$?
 	echo


### PR DESCRIPTION
Hi @carol-hsu 

This PR includes to enable IP Masquerade on Flanneld that we found a solution yesterday.
Please try this on minion both Amazon Linux and CentOS 7.


Hi @msfuko 

Here is a solution for the issue of https://github.com/TrendMicroDCS/qa-sample-service/pull/1 FYI.
As my understanding, if we want to use Kubernetes service (proxy) that want to send a packet to outside (ex: use AWS API from container), we need

- Enable Flanneld IP Masquerade (-ip-masq=true)
- Use iptables 1.4.11 or later to avoid iptables rule growth  (according to Kubernetes source code, iptables < 1.4.11 possibly has a issue : https://github.com/GoogleCloudPlatform/kubernetes/blob/master/pkg/util/iptables/iptables.go#L214)

it seems CentOS 7 can be satisfied our requirement (also Amazon Linux), we already re-install CentOS7 on qaworker1 to confirmed it works perfectly. please prepare other machines to do so.