### PR TITLE
Etcd clustering

### DIFF
--- a/kubernetes/recipes/etcd-auth.rb
+++ b/kubernetes/recipes/etcd-auth.rb
@@ -1,0 +1,24 @@
+template "/root/etcd_enable_ba.sh" do
+    mode "0755"
+    owner "root"
+    source "etcd_enable_ba.sh.erb"
+    variables :etcd_password => node[:etcd_password]
+    notifies :run, "bash[ba_setup]", :delayed
+end
+
+bash 'ba_setup' do
+    user 'root'
+    cwd '/root'
+    code <<-EOH
+    tries=0
+    while [ $tries -lt 10 ]; do
+        sleep 1
+        tries=$((tries + 1))
+    done
+
+    /root/etcd_enable_ba.sh
+
+    EOH
+
+    action :nothing
+end

--- a/kubernetes/recipes/etcd-clustering.rb
+++ b/kubernetes/recipes/etcd-clustering.rb
@@ -20,7 +20,7 @@ template "/root/etcd_static_bootstrap.sh" do
 end
 
 service 'etcd' do
-    action :nothing
+	action :nothing
 	notifies :run, "bash[etcd_bootstrap]", :delayed
 end
 

--- a/kubernetes/recipes/etcd-clustering.rb
+++ b/kubernetes/recipes/etcd-clustering.rb
@@ -1,7 +1,3 @@
-service 'etcd' do
-    action :stop
-end
-
 private_ip = node['opsworks']['instance']['private_ip']
 hostname = node['opsworks']['instance']['hostname']
 members = Array.new
@@ -20,6 +16,11 @@ template "/root/etcd_static_bootstrap.sh" do
 		:private_ip => private_ip,
 		:token_postfix => node[:token]
 	})
+	notifies :stop, "service[etcd]", :delayed
+end
+
+service 'etcd' do
+    action :nothing
 	notifies :run, "bash[etcd_bootstrap]", :delayed
 end
 
@@ -30,4 +31,5 @@ bash 'etcd_bootstrap' do
 	rm -rf #{hostname}.etcd
 	./etcd_static_bootstrap.sh
 	EOH
+	action :nothing
 end

--- a/kubernetes/recipes/etcd-clustering.rb
+++ b/kubernetes/recipes/etcd-clustering.rb
@@ -1,0 +1,33 @@
+service 'etcd' do
+    action :stop
+end
+
+private_ip = node['opsworks']['instance']['private_ip']
+hostname = node['opsworks']['instance']['hostname']
+members = Array.new
+
+node['opsworks']['layers']['etcd']['instances'].each do |inst|
+	members << inst[0]+"=http://"+inst[1][:private_ip]+":7001"
+end
+
+template "/root/etcd_static_bootstrap.sh" do
+	mode "0755"
+	owner "root"
+	source "etcd_static_bootstrap.sh.erb"
+	variables ({
+		:hostname => hostname,
+		:members => members.join(','),
+		:private_ip => private_ip,
+		:token_postfix => node[:token]
+	})
+	notifies :run, "bash[etcd_bootstrap]", :delayed
+end
+
+bash 'etcd_bootstrap' do
+	user 'root'
+	cwd '/root'
+	code <<-EOH
+	rm -rf #{hostname}.etcd
+	./etcd_static_bootstrap.sh
+	EOH
+end

--- a/kubernetes/recipes/etcd-daemon-clustering.rb
+++ b/kubernetes/recipes/etcd-daemon-clustering.rb
@@ -15,7 +15,7 @@ bash "update_new_setting" do
 	user 'root'
 	cwd '/etc/init.d'
 	code <<-EOH
-	sed -i '33c ///t//t-initial-advertise-peer-urls http://#{private_ip}:7001 -listen-peer-urls http://#{private_ip}:7001 -listen-client-urls http://#{private_ip}:4001,http://127.0.0.1:4001 -advertise-client-urls http://#{private_ip}:4001 -initial-cluster-token etcd-cluster-#{node[:token]} -initial-cluster #{members.join(',')} -initial-cluster-state new ///' etcd
+	sed -i '33c \\\t\\\t-initial-advertise-peer-urls http://#{private_ip}:7001 -listen-peer-urls http://#{private_ip}:7001 -listen-client-urls http://#{private_ip}:4001,http://127.0.0.1:4001 -advertise-client-urls http://#{private_ip}:4001 -initial-cluster-token etcd-cluster-#{node[:token]} -initial-cluster #{members.join(',')} -initial-cluster-state new \\\' etcd
 	EOH
 	action :nothing
 	notifies :start, "service[etcd]", :delayed

--- a/kubernetes/recipes/etcd-daemon-clustering.rb
+++ b/kubernetes/recipes/etcd-daemon-clustering.rb
@@ -13,9 +13,9 @@ end
 
 bash "update_new_setting" do
 	user 'root'
-	cwd '/etc/init.d'
+	
 	code <<-EOH
-	sed -i '33c \\\t\\t-initial-advertise-peer-urls http://#{private_ip}:7001 -listen-peer-urls http://#{private_ip}:7001 -listen-client-urls http://#{private_ip}:4001,http://127.0.0.1:4001 -advertise-client-urls http://#{private_ip}:4001 -initial-cluster-token etcd-cluster-#{node[:token]} -initial-cluster #{members.join(',')} -initial-cluster-state new \\\\' etcd
+	sed -i '33c \\\t\\t-initial-advertise-peer-urls http://#{private_ip}:7001 -listen-peer-urls http://#{private_ip}:7001 -listen-client-urls http://#{private_ip}:4001,http://127.0.0.1:4001 -advertise-client-urls http://#{private_ip}:4001 -initial-cluster-token etcd-cluster-#{node[:token]} -initial-cluster #{members.join(',')} -initial-cluster-state new \\\\' /etc/init.d/etcd
 	service etcd start
 	EOH
 	action :nothing

--- a/kubernetes/recipes/etcd-daemon-clustering.rb
+++ b/kubernetes/recipes/etcd-daemon-clustering.rb
@@ -1,0 +1,23 @@
+private_ip = node['opsworks']['instance']['private_ip']
+hostname = node['opsworks']['instance']['hostname']
+members = Array.new
+
+node['opsworks']['layers']['etcd']['instances'].each do |inst|
+	members << inst[0]+"=http://"+inst[1][:private_ip]+":7001"
+end
+
+service 'etcd' do
+	action :stop
+	notifies :run, "bash[update_new_setting]", :delayed
+end
+
+bash "update_new_setting" do
+	user 'root'
+	cwd '/etc/init.d'
+	code <<-EOH
+	sed -i '33c -initial-advertise-peer-urls http://#{private_ip}:7001 -listen-peer-urls http://#{private_ip}:7001 -listen-client-urls http://#{private_ip}:4001,http://127.0.0.1:4001 -advertise-client-urls http://#{private_ip}:4001 -initial-cluster-token etcd-cluster-#{node[:token]} -initial-cluster #{members.join(',')} -initial-cluster-state new' etcd
+	EOH
+	action :nothing
+	notifies :start, "service[etcd]", :delayed
+end
+

--- a/kubernetes/recipes/etcd-daemon-clustering.rb
+++ b/kubernetes/recipes/etcd-daemon-clustering.rb
@@ -15,7 +15,7 @@ bash "update_new_setting" do
 	user 'root'
 	cwd '/etc/init.d'
 	code <<-EOH
-	sed -i '33c -initial-advertise-peer-urls http://#{private_ip}:7001 -listen-peer-urls http://#{private_ip}:7001 -listen-client-urls http://#{private_ip}:4001,http://127.0.0.1:4001 -advertise-client-urls http://#{private_ip}:4001 -initial-cluster-token etcd-cluster-#{node[:token]} -initial-cluster #{members.join(',')} -initial-cluster-state new' etcd
+	sed -i '33c ///t//t-initial-advertise-peer-urls http://#{private_ip}:7001 -listen-peer-urls http://#{private_ip}:7001 -listen-client-urls http://#{private_ip}:4001,http://127.0.0.1:4001 -advertise-client-urls http://#{private_ip}:4001 -initial-cluster-token etcd-cluster-#{node[:token]} -initial-cluster #{members.join(',')} -initial-cluster-state new ///' etcd
 	EOH
 	action :nothing
 	notifies :start, "service[etcd]", :delayed

--- a/kubernetes/recipes/etcd-daemon-clustering.rb
+++ b/kubernetes/recipes/etcd-daemon-clustering.rb
@@ -16,8 +16,8 @@ bash "update_new_setting" do
 	cwd '/etc/init.d'
 	code <<-EOH
 	sed -i '33c \\\t\\\t-initial-advertise-peer-urls http://#{private_ip}:7001 -listen-peer-urls http://#{private_ip}:7001 -listen-client-urls http://#{private_ip}:4001,http://127.0.0.1:4001 -advertise-client-urls http://#{private_ip}:4001 -initial-cluster-token etcd-cluster-#{node[:token]} -initial-cluster #{members.join(',')} -initial-cluster-state new \\\' etcd
+	service etcd start
 	EOH
 	action :nothing
-	notifies :start, "service[etcd]", :delayed
 end
 

--- a/kubernetes/recipes/etcd-daemon-clustering.rb
+++ b/kubernetes/recipes/etcd-daemon-clustering.rb
@@ -15,7 +15,7 @@ bash "update_new_setting" do
 	user 'root'
 	cwd '/etc/init.d'
 	code <<-EOH
-	sed -i '33c \\\t\\\t-initial-advertise-peer-urls http://#{private_ip}:7001 -listen-peer-urls http://#{private_ip}:7001 -listen-client-urls http://#{private_ip}:4001,http://127.0.0.1:4001 -advertise-client-urls http://#{private_ip}:4001 -initial-cluster-token etcd-cluster-#{node[:token]} -initial-cluster #{members.join(',')} -initial-cluster-state new \\\' etcd
+	sed -i '33c \\\t\\t-initial-advertise-peer-urls http://#{private_ip}:7001 -listen-peer-urls http://#{private_ip}:7001 -listen-client-urls http://#{private_ip}:4001,http://127.0.0.1:4001 -advertise-client-urls http://#{private_ip}:4001 -initial-cluster-token etcd-cluster-#{node[:token]} -initial-cluster #{members.join(',')} -initial-cluster-state new \\\\' etcd
 	service etcd start
 	EOH
 	action :nothing

--- a/kubernetes/recipes/etcd.rb
+++ b/kubernetes/recipes/etcd.rb
@@ -27,23 +27,5 @@ template "/root/etcd_enable_ba.sh" do
     owner "root"
     source "etcd_enable_ba.sh.erb"
     variables :etcd_password => node[:etcd_password]
-    notifies :run, "bash[ba_setup]", :delayed
-end
-
-bash 'ba_setup' do
-    user 'root'
-    cwd '/root'
-    code <<-EOH
-    tries=0
-    while [ $tries -lt 10 ]; do
-        sleep 1
-        tries=$((tries + 1))
-    done
-
-    /root/etcd_enable_ba.sh
-
-    EOH
-
-    action :nothing
 end
 

--- a/kubernetes/templates/default/etcd_static_bootstrap.sh.erb
+++ b/kubernetes/templates/default/etcd_static_bootstrap.sh.erb
@@ -1,0 +1,22 @@
+#! /bin/bash
+
+etcd -name <%= @hostname %> \
+        -initial-advertise-peer-urls http://<%= @private_ip %>:7001 \
+        -listen-peer-urls http://<%= @private_ip %>:7001 \
+        -listen-client-urls http://<%= @private_ip %>:4001,http://127.0.0.1:4001 \
+        -advertise-client-urls http://<%= @private_ip %>:4001 \
+        -initial-cluster-token etcd-cluster-<%= @token_postfix %> \
+        -initial-cluster <%= @members %> \
+        -initial-cluster-state new > /var/log/etcd_bootstrap.log 2>&1 &
+
+#check if the member is added
+while true; do
+	previous=$(ls -l /var/log/etcd_bootstrap.log | awk '{print $5}')
+	sleep 5
+	current=$(ls -l /var/log/etcd_bootstrap.log | awk '{print $5}')
+	if [ "$previous" == "$current" ]; then
+		break
+	fi
+done
+
+echo "etcd clustering is finished!"


### PR DESCRIPTION
Hi @hidetosaito ,

this PR is for etcd clustering, which should be executed whenever new node added: 
need to know every member's ip address  for clustering

and for authentication, I move it out from "setup".
since for clustering, to avoid confliction, only single member of cluster can execute the recipe to enable authentication. 

Thanks