### PR TITLE
add docker cronjob for disk cleaness/add authentication method in clustering recipe

### DIFF
--- a/kubernetes/recipes/etcd-clustering.rb
+++ b/kubernetes/recipes/etcd-clustering.rb
@@ -1,9 +1,14 @@
 private_ip = node['opsworks']['instance']['private_ip']
 hostname = node['opsworks']['instance']['hostname']
 members = Array.new
+smallest_ip = 255
 
 node['opsworks']['layers']['etcd']['instances'].each do |inst|
 	members << inst[0]+"=http://"+inst[1][:private_ip]+":7001"
+	last_num = inst[1][:private_ip].split('.')[3]
+	if last_num.to_i < smallest_ip
+		smallest_ip = last_num.to_i
+	end
 end
 
 template "/root/etcd_static_bootstrap.sh" do
@@ -33,3 +38,30 @@ bash 'etcd_bootstrap' do
 	EOH
 	action :nothing
 end
+
+if private_ip.split('.')[3].to_i == smallest_ip
+	template "/root/etcd_enable_ba.sh" do
+	    mode "0755"
+	    owner "root"
+	    source "etcd_enable_ba.sh.erb"
+	    variables :etcd_password => node[:etcd_password]
+	end
+	
+	bash 'ba_setup' do
+	    user 'root'
+	    cwd '/root'
+	    code <<-EOH
+	    tries=0
+	    while [ $tries -lt 10 ]; do
+	        sleep 1
+	        tries=$((tries + 1))
+	    done
+	
+	    /root/etcd_enable_ba.sh
+	
+	    EOH
+	    action :nothing
+	    subscribes :run, "bash[etcd_bootstrap]", :delayed
+	end
+end
+

--- a/kubernetes/recipes/etcd-clustering.rb
+++ b/kubernetes/recipes/etcd-clustering.rb
@@ -1,13 +1,12 @@
 private_ip = node['opsworks']['instance']['private_ip']
 hostname = node['opsworks']['instance']['hostname']
 members = Array.new
-smallest_ip = 255
+ip_enable_ba = nil
 
 node['opsworks']['layers']['etcd']['instances'].each do |inst|
 	members << inst[0]+"=http://"+inst[1][:private_ip]+":7001"
-	last_num = inst[1][:private_ip].split('.')[3]
-	if last_num.to_i < smallest_ip
-		smallest_ip = last_num.to_i
+	if ip_enable_ba == nil
+		ip_enable_ba = inst[1][:private_ip]
 	end
 end
 
@@ -39,7 +38,7 @@ bash 'etcd_bootstrap' do
 	action :nothing
 end
 
-if private_ip.split('.')[3].to_i == smallest_ip
+if private_ip == ip_enable_ba
 	template "/root/etcd_enable_ba.sh" do
 	    mode "0755"
 	    owner "root"

--- a/kubernetes/recipes/etcd.rb
+++ b/kubernetes/recipes/etcd.rb
@@ -22,10 +22,3 @@ service "etcd" do
 	subscribes :reload, "template[/root/etcd_enable_ba.sh]", :immediately	
 end
 
-template "/root/etcd_enable_ba.sh" do
-    mode "0755"
-    owner "root"
-    source "etcd_enable_ba.sh.erb"
-    variables :etcd_password => node[:etcd_password]
-end
-


### PR DESCRIPTION
Hi @msfuko 

this script is help for docker's disk management 
I already add it in D/C minions, and confirmed that they would be triggered
```
cron:Sep 10 03:12:01 dcs-qaworker5 run-parts(/etc/cron.daily)[27460]: starting docker-clean.cron
cron:Sep 10 03:12:01 dcs-qaworker5 run-parts(/etc/cron.daily)[27477]: finished docker-clean.cron
```

let's wait for it how it works when the disk is less than 20% :jack_o_lantern: 

Thanks
Carol