### PR TITLE
rollback flanneld version to 0.5.2

### DIFF
--- a/kubernetes/recipes/flanneld.rb
+++ b/kubernetes/recipes/flanneld.rb
@@ -3,9 +3,9 @@ bash 'install_flannel' do
   cwd '/tmp'
   code <<-EOH
   if [ ! -f /usr/local/bin/flanneld ]; then
-    wget --max-redirect 255 https://github.com/coreos/flannel/releases/download/v0.5.5/flannel-0.5.5-linux-amd64.tar.gz
-    tar zxvf flannel-0.5.5-linux-amd64.tar.gz
-    cd flannel-0.5.5
+    wget --max-redirect 255 https://github.com/coreos/flannel/releases/download/v0.5.2/flannel-0.5.2-linux-amd64.tar.gz
+    tar zxvf flannel-0.5.2-linux-amd64.tar.gz
+    cd flannel-0.5.2
     cp flanneld /usr/local/bin
     cp mk-docker-opts.sh /opt/
   fi


### PR DESCRIPTION
may got iptable error "no tag --wait" for version 0.5.5